### PR TITLE
Fix bug when less entries are given than the configured numberOfResults

### DIFF
--- a/MMM-Vrr.js
+++ b/MMM-Vrr.js
@@ -134,6 +134,10 @@ Module.register("MMM-Vrr", {
      */
     delayExist: function (apiResult) {
         for (let i = 0; i < this.config.numberOfResults; i++) {
+            if (apiResult.raw[i] === undefined) {
+                continue;
+            }
+
             if (apiResult.raw[i].delay > 0) {
                 return true;
             }
@@ -220,6 +224,10 @@ Module.register("MMM-Vrr", {
         for (let trCounter = 0; trCounter < self.config.numberOfResults; trCounter++) {
 
             let obj = usableResults[trCounter];
+            if (obj === undefined) {
+                continue;
+            }
+
             // check destination
             if (self.config.withoutDestination.length > 0) {
                 let found = false;


### PR DESCRIPTION
Bug: Module was not displayed when less entries were provided by the api call than the configured "numberOfResults" count.

Example configuration:
```
{
	module: 'MMM-Vrr',
	position: "top_right",
	config: {
		city: 'Düsseldorf',
		station: 'Münsterstraße/Feuerwache',
		numberOfResults: 5,
		displayTimeOption: 'countdown',
		displayType: 'detail',
		platform: '2',
		line: '752'
	}
}
```
(will produce two entries on a sunday)