### PR TITLE
Add support for urban rail symbol type

### DIFF
--- a/MMM-Vrr.js
+++ b/MMM-Vrr.js
@@ -93,10 +93,10 @@ Module.register("MMM-Vrr", {
    */
   getData: function () {
     let self = this;
-
+  
     let urlApi = this.getUrl();
     let retry = true;
-
+  
     let dataRequest = new XMLHttpRequest();
     dataRequest.open("GET", urlApi, true);
     dataRequest.onreadystatechange = function () {
@@ -108,12 +108,15 @@ Module.register("MMM-Vrr", {
           Log.error(self.name, this.status);
           retry = false;
         } else {
-          Log.error(self.name, "Could not load data.");
+          Log.error(self.name, "Could not load data. Status: " + this.status + ", Error: " + this.statusText);
         }
         if (retry) {
           self.scheduleUpdate(self.loaded ? -1 : self.config.retryDelay);
         }
       }
+    };
+    dataRequest.onerror = function () {
+      Log.error(self.name, "API request failed: " + urlApi);
     };
     dataRequest.send();
   },

--- a/MMM-Vrr.js
+++ b/MMM-Vrr.js
@@ -102,13 +102,16 @@ Module.register("MMM-Vrr", {
     dataRequest.onreadystatechange = function () {
       if (this.readyState === 4) {
         if (this.status === 200) {
-          self.processData(JSON.parse(this.response));
+          Log.info(self.name + ": Data successfully loaded.");
+          let data = JSON.parse(this.response);
+          Log.info(self.name + ": Data to be processed: " + JSON.stringify(data));
+          self.processData(data);
         } else if (this.status === 401) {
           self.updateDom(self.config.animationSpeed);
-          Log.error(self.name, this.status);
+          Log.error(self.name + ": Unauthorized access. Status: " + this.status);
           retry = false;
         } else {
-          Log.error(self.name, "Could not load data. Status: " + this.status + ", Error: " + this.statusText);
+          Log.error(self.name + ": Could not load data. Status: " + this.status + ", Status Text: " + this.statusText + ", Response: " + this.responseText);
         }
         if (retry) {
           self.scheduleUpdate(self.loaded ? -1 : self.config.retryDelay);
@@ -116,7 +119,7 @@ Module.register("MMM-Vrr", {
       }
     };
     dataRequest.onerror = function () {
-      Log.error(self.name, "API request failed: " + urlApi);
+      Log.error(self.name + ": API request failed. URL: " + urlApi);
     };
     dataRequest.send();
   },

--- a/MMM-Vrr.js
+++ b/MMM-Vrr.js
@@ -409,6 +409,9 @@ Module.register("MMM-Vrr", {
       case "TaxiBus":
         symbolType = "taxi";
         break;
+      case "Stadtbahn":
+        symbolType = "subway"; 
+        break;
       default:
         symbolType = "bus";
         break;


### PR DESCRIPTION
There are so-called “Stadtbahnen” in the VRS area. In principle, these are subway trains, but sometimes they also run on the road. I have simply added another element to the switch case statement so that the normal subway symbol is now also displayed for “Stadtbahnen”. 